### PR TITLE
Support functions as series' color attribute

### DIFF
--- a/jquery.flot.bubbles.js
+++ b/jquery.flot.bubbles.js
@@ -134,6 +134,9 @@ THE SOFTWARE.
 			y = offset.top + serie.yaxis.p2c(data[1]);
 			v = data[2];
 			r = parseInt(serie.yaxis.scale * data[2] / 2, 0);
+			if(typeof c === 'function') {
+				c = c.apply(this, data);
+			}
 			serie.bubbles.drawbubble(ctx, serie, x, y, v, r, c, overlay);
 		};
 


### PR DESCRIPTION
Hi,

this patch adds the ability to specify series' color with a function.  The data triples are passed to the function in turn, and the function is expected to return color codes.

User story:  I wanted to colorize the drawn bubbles based on their closeness to a certain regression line.  I.e. if the bubbles are very close to the regression line, paint them in green.  If they are farer away, then yellow etc.

cheers,
~stesie
