### PR TITLE
Findfirst

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ var p4 = $.plot( $("#plot"), [ d1, { color: '#AAA', data: d2 }], options );
          * **findItem:** Function call to find item under Cursor. Is overwritten during processRawData hook. This would be the place to add your own find function, which will not be overwritten. (findNearbyItemDefault(mouseX,mouseY,i,serie))
          * **drawEdit:** function to draw edit marker. It is defined in jquery.flot.mouse plugin, and is overwritten in plugin to support specific editmarkers (drawEditDefault(octx,x,y,serie))
          * **drawHover:** Function to draw overlay in case of hover a item. Is overwritten during processRawData hook. This would be the place to add your own hover drawing function. (drawHoverDefault(octx,serie,dataIndex))
+      * **findMode:** Choose between selecting either the most nearby bubble, or the first one that is encountered. (nearby)
 
 ### Options
 

--- a/jquery.flot.bubbles.js
+++ b/jquery.flot.bubbles.js
@@ -43,7 +43,8 @@ THE SOFTWARE.
 				bubblelabel: {
 					show: false,
 					fillStyle: "black"
-				}
+				},
+				findMode: 'nearest'
 			}
 		}
 	};
@@ -210,6 +211,11 @@ THE SOFTWARE.
 						}
 					}
 				}
+
+				if (s.bubbles.findMode === 'first' && item) {
+					break;
+				}
+
 			}
 
 			if (item) {


### PR DESCRIPTION
By default, the findNearbyItem function returns the bubble most closest to the mouse cursor. This gives unexpected results with larger bubbles that overlap eachother, returning underlying items instead of the bubble the mouse is currently hovering over. The added 'findMode' option allows you to select either 'nearby' (default) or 'first' (first encountered bubble from the top down). If the option is left blank, the function behaves like normal, returning the most nearby bubble.
